### PR TITLE
Fix subpath deployments

### DIFF
--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,6 +1,4 @@
-WOODPECKER_HOST={{ devture_woodpecker_ci_server_config_host }}
-
-WOODPECKER_ROOT_URL={{ devture_woodpecker_ci_server_config_root_url }}
+WOODPECKER_HOST={{ devture_woodpecker_ci_server_config_host }}{{ devture_woodpecker_ci_server_config_root_url }}
 
 WOODPECKER_OPEN={{ devture_woodpecker_ci_server_config_open | to_json }}
 

--- a/templates/labels.j2
+++ b/templates/labels.j2
@@ -13,11 +13,6 @@ traefik.http.middlewares.{{ devture_woodpecker_ci_server_identifier }}-slashless
 {% set middlewares = middlewares + [devture_woodpecker_ci_server_identifier + '-slashless-redirect'] %}
 {% endif %}
 
-{% if devture_woodpecker_ci_server_container_labels_traefik_path_prefix != '/' %}
-traefik.http.middlewares.{{ devture_woodpecker_ci_server_identifier }}-strip-prefix.stripprefix.prefixes={{ devture_woodpecker_ci_server_container_labels_traefik_path_prefix }}
-{% set middlewares = middlewares + [devture_woodpecker_ci_server_identifier + '-strip-prefix'] %}
-{% endif %}
-
 {% if devture_woodpecker_ci_server_container_labels_traefik_additional_response_headers.keys() | length > 0 %}
 {% for name, value in devture_woodpecker_ci_server_container_labels_traefik_additional_response_headers.items() %}
 traefik.http.middlewares.{{ devture_woodpecker_ci_server_identifier }}-add-headers.headers.customresponseheaders.{{ name }}={{ value }}


### PR DESCRIPTION
Ref.: https://github.com/mother-of-all-self-hosting/mash-playbook/issues/151

Upstream made some modifications to the way the subpath (root URL)
should be provided.  Also, I found that the traefik strip-prefix label
needs to be removed otherwise Woodpecker gets confused and won't serve
its assets properly.