### PR TITLE
Implement gRPC support for Woodpecker Server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -154,6 +154,26 @@ devture_woodpecker_ci_server_container_labels_traefik_entrypoints: web-secure
 devture_woodpecker_ci_server_container_labels_traefik_tls: "{{ devture_woodpecker_ci_server_container_labels_traefik_entrypoints != 'web' }}"
 devture_woodpecker_ci_server_container_labels_traefik_tls_certResolver: default  # noqa var-naming
 
+# devture_woodpecker_ci_server_container_labels_traefik_grpc_enabled controls whether
+# to expose the gRPC port externally.  Set this to true if you plan to run Woodpecker agents
+# on separate machines/networks.
+devture_woodpecker_ci_server_container_labels_traefik_grpc_enabled: false
+# The following regexp is used to match the Protobuf endpoints.
+#
+# Note that even if you are serving Woodpecker under a prefix (e.g., `/ci`), these endpoints will *not*
+# use the prefix.  For example, if your Woodpecker server instance lives at https://example.com/ci, these
+# endpoints will respond at https://example.com/proto.Woodpecker(Auth)?.
+#
+# This setup has been inspired by:
+# https://www.nemunai.re/post/woodpecker-ci-mixing-http-grpc-on-one-domain-nginx/
+devture_woodpecker_ci_server_container_labels_traefik_grpc_path_prefix_woodpecker: '/proto.Woodpecker'
+devture_woodpecker_ci_server_container_labels_traefik_grpc_path_prefix_woodpeckerauth: '/proto.WoodpeckerAuth'
+devture_woodpecker_ci_server_container_labels_traefik_grpc_rule: "Host(`{{ devture_woodpecker_ci_server_container_labels_traefik_hostname }}`) && (PathPrefix(`{{ devture_woodpecker_ci_server_container_labels_traefik_grpc_path_prefix_woodpecker }}`) || PathPrefix(`{{ devture_woodpecker_ci_server_container_labels_traefik_grpc_path_prefix_woodpeckerauth }}`))"
+devture_woodpecker_ci_server_container_labels_traefik_grpc_priority: 0
+devture_woodpecker_ci_server_container_labels_traefik_grpc_entrypoints: web-secure
+devture_woodpecker_ci_server_container_labels_traefik_grpc_tls: "{{ devture_woodpecker_ci_server_container_labels_traefik_grpc_entrypoints != 'web' }}"
+devture_woodpecker_ci_server_container_labels_traefik_grpc_tls_certResolver: default  # noqa var-naming
+
 # Controls which additional headers to attach to all HTTP responses.
 # To add your own headers, use `devture_woodpecker_ci_server_container_labels_traefik_additional_response_headers_custom`
 devture_woodpecker_ci_server_container_labels_traefik_additional_response_headers: "{{ devture_woodpecker_ci_server_container_labels_traefik_additional_response_headers_auto | combine(devture_woodpecker_ci_server_container_labels_traefik_additional_response_headers_custom) }}"

--- a/templates/labels.j2
+++ b/templates/labels.j2
@@ -35,6 +35,24 @@ traefik.http.routers.{{ devture_woodpecker_ci_server_identifier }}.tls.certResol
 {% endif %}
 
 traefik.http.services.{{ devture_woodpecker_ci_server_identifier }}.loadbalancer.server.port=8000
+
+{% if devture_woodpecker_ci_server_container_labels_traefik_grpc_enabled %}
+# gRPC
+traefik.http.routers.{{ devture_woodpecker_ci_server_identifier }}-grpc.rule={{ devture_woodpecker_ci_server_container_labels_traefik_grpc_rule }}
+{% if devture_woodpecker_ci_server_container_labels_traefik_grpc_priority | int > 0 %}
+traefik.http.routers.{{ devture_woodpecker_ci_server_identifier }}-grpc.priority={{ devture_woodpecker_ci_server_container_labels_traefik_grpc_priority }}
+{% endif %}
+traefik.http.routers.{{ devture_woodpecker_ci_server_identifier }}-grpc.service={{ devture_woodpecker_ci_server_identifier }}-grpc
+traefik.http.routers.{{ devture_woodpecker_ci_server_identifier }}-grpc.entrypoints={{ devture_woodpecker_ci_server_container_labels_traefik_grpc_entrypoints }}
+traefik.http.routers.{{ devture_woodpecker_ci_server_identifier }}-grpc.tls={{ devture_woodpecker_ci_server_container_labels_traefik_grpc_tls | to_json }}
+{% if devture_woodpecker_ci_server_container_labels_traefik_grpc_tls %}
+traefik.http.routers.{{ devture_woodpecker_ci_server_identifier }}-grpc.tls.certResolver={{ devture_woodpecker_ci_server_container_labels_traefik_grpc_tls_certResolver }}
+{% endif %}
+
+traefik.http.services.{{ devture_woodpecker_ci_server_identifier }}-grpc.loadbalancer.server.port={{ devture_woodpecker_ci_server_config_grpc_addr_port }}
+traefik.http.services.{{ devture_woodpecker_ci_server_identifier }}-grpc.loadbalancer.server.scheme=h2c
+{% endif %}
+
 {% endif %}
 
 {{ devture_woodpecker_ci_server_container_labels_additional_labels }}


### PR DESCRIPTION
This PR implements gRPC support for Woodpecker Server.

Upstream suggests that the gRPC service should have its own domain,
but this is not necessary and complicates things.  Instead, I decided
to filter out Protobuf requests (which is what Woodpecker's gRPC uses)
and redirect them to the proper port.

Since we only need to worry about these redirections when listening
for gRPC connections coming from outside, there's a new configuration
variable to enable this behaviour.